### PR TITLE
Updating Script to NodeScript to match change in Node.js introduced in v...

### DIFF
--- a/vendor/jsdoc/app/run.js
+++ b/vendor/jsdoc/app/run.js
@@ -9,7 +9,7 @@
 
 // load the node.js libraries to be abstracted
 var fs = require('fs');
-var Script = process.binding('evals').Script;
+var Script = process.binding('evals').NodeScript;
 
 // define a few globals to be compatible with jsrun.jar
 global.arguments = process.argv.slice(2);


### PR DESCRIPTION
...0.4.4

In Node.js v0.4.4 the Script class was renamed to NodeScript to avoid confusion with V8's own Script class.  This causes the sc-docs run.js to fail with an exception when generating documentation.  This commit merely changes Script to NodeScript in vendor/jsdoc/apps/run.js

[Node.js Pull Request](https://github.com/fictivekin/webshell/pull/29)
[Node.js NodeScript Change](https://github.com/joyent/node/commit/75db1995b6529cb71513a45299e2ba742e7afde9)
